### PR TITLE
[IMP] automatically remove @odoo-module from js assets

### DIFF
--- a/odoo_module_migrate/migration_scripts/migrate_170_180.py
+++ b/odoo_module_migrate/migration_scripts/migrate_170_180.py
@@ -100,9 +100,34 @@ def replace_user_has_groups(
             logger.error(f"Error processing file {file}: {str(e)}")
 
 
+def replace_odoo_module_from_js_assets(
+    logger, module_path, module_name, manifest_path, migration_steps, tools
+):
+    files_to_process = tools.get_files(module_path, (".js",))
+    replaces = {
+        r"/\*\*\s*@odoo-module\s*\*\*/\s*\n?": "",
+        r"/\*\s*@odoo-module\s*\*/\s*\n?": "",
+        r"/\*\*\s*@odoo-module\s*\*/\s*\n?": "",
+        r"/\*\s*@odoo-module\s*\*\*/\s*\n?": "",
+    }
+    for file in files_to_process:
+        file_str = str(file)
+        if not ("/static/src" in file_str or "/static/tests" in file_str):
+            continue
+        try:
+            tools._replace_in_file(
+                file,
+                replaces,
+                log_message=f"Remove @odoo-module from js assets in file: {file}",
+            )
+        except Exception as e:
+            logger.error(f"Error processing file {file}: {str(e)}")
+
+
 class MigrationScript(BaseMigrationScript):
     _GLOBAL_FUNCTIONS = [
         replace_tree_with_list_in_views,
         replace_chatter_blocks,
         replace_user_has_groups,
+        replace_odoo_module_from_js_assets,
     ]

--- a/tests/data_result/module_170_180/__manifest__.py
+++ b/tests/data_result/module_170_180/__manifest__.py
@@ -11,4 +11,9 @@
     'data': [
         'views/res_partner.xml',
     ],
+    'assets': {
+        'web.assets_backend': [
+            'module_170/static/src/js/main.js',
+        ],
+    },
 }

--- a/tests/data_result/module_170_180/static/file_not_process.js
+++ b/tests/data_result/module_170_180/static/file_not_process.js
@@ -1,0 +1,4 @@
+/** @odoo-module **/
+
+// example js file include tag @odoo-module but not process this file
+// because it does not in static/src or static/tests

--- a/tests/data_result/module_170_180/static/src/js/main.js
+++ b/tests/data_result/module_170_180/static/src/js/main.js
@@ -1,0 +1,1 @@
+// example js file include tag @odoo-module

--- a/tests/data_template/module_170/__manifest__.py
+++ b/tests/data_template/module_170/__manifest__.py
@@ -11,4 +11,9 @@
     'data': [
         'views/res_partner.xml',
     ],
+    'assets': {
+        'web.assets_backend': [
+            'module_170/static/src/js/main.js',
+        ],
+    },
 }

--- a/tests/data_template/module_170/static/file_not_process.js
+++ b/tests/data_template/module_170/static/file_not_process.js
@@ -1,0 +1,4 @@
+/** @odoo-module **/
+
+// example js file include tag @odoo-module but not process this file
+// because it does not in static/src or static/tests

--- a/tests/data_template/module_170/static/src/js/main.js
+++ b/tests/data_template/module_170/static/src/js/main.js
@@ -1,0 +1,6 @@
+/** @odoo-module **/
+/* @odoo-module */
+/** @odoo-module */
+/* @odoo-module **/
+
+// example js file include tag @odoo-module


### PR DESCRIPTION
no need for /** @odoo-module */ anymore

automatically remove it from js assets: `https://github.com/odoo/odoo/pull/142858/`