### PR TITLE
[IMP] replace toggle_button to boolean_toggle widget

### DIFF
--- a/odoo_module_migrate/migration_scripts/migrate_150_allways.py
+++ b/odoo_module_migrate/migration_scripts/migrate_150_allways.py
@@ -1,0 +1,28 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo_module_migrate.base_migration_script import BaseMigrationScript
+
+
+def replace_toggle_button(
+    logger, module_path, module_name, manifest_path, migration_steps, tools
+):
+    files_to_process = tools.get_files(module_path, (".xml",))
+    replaces = {
+        r'widget="\s*toggle_button\s*"': 'widget="boolean_toggle"',
+        r"widget='\s*toggle_button\s*'": 'widget="boolean_toggle"',
+        r'<attribute\s+name=["\']widget["\']>\s*toggle_button\s*</attribute>': '<attribute name="widget">boolean_toggle</attribute>',
+    }
+
+    for file in files_to_process:
+        try:
+            tools._replace_in_file(
+                file,
+                replaces,
+                log_message=f"Replace toggle_button widget to boolean_toggle widget in file: {file}",
+            )
+        except Exception as e:
+            logger.error(f"Error processing file {file}: {str(e)}")
+
+
+class MigrationScript(BaseMigrationScript):
+    _GLOBAL_FUNCTIONS = [replace_toggle_button]

--- a/tests/data_result/module_160_170/views/res_partner.xml
+++ b/tests/data_result/module_160_170/views/res_partner.xml
@@ -10,6 +10,7 @@
                     <tree editable="bottom" delete="false">
                         <field name="id"/>
                         <field name="name"/>
+                        <field name="active" widget="boolean_toggle" string="Still Active"/>
                         <button name="get_formview_action" type="object" title="Open Task" icon="fa-pencil-square-o"/>
                     </tree>
                 </field>

--- a/tests/data_result/module_170_180/views/res_partner.xml
+++ b/tests/data_result/module_170_180/views/res_partner.xml
@@ -7,6 +7,7 @@
             <!-- This is a list view for partners -->
             <list position="inside">
                 <field name="test_field_1"/>
+                <field name="active" widget="boolean_toggle"/>
             </list>
         </field>
     </record>
@@ -35,6 +36,15 @@
                 <list>
                     <field name="name"/>
                 </list>
+            </xpath>
+            <xpath expr="//field[@name='active']" position="attributes">
+                <attribute name="widget">boolean_toggle</attribute>
+            </xpath>
+            <xpath expr="//field[@name='active']" position="attributes">
+                <attribute name="widget">boolean_toggle</attribute>
+            </xpath>
+            <xpath expr="//field[@name='active']" position="attributes">
+                <attribute name="widget">boolean_toggle</attribute>
             </xpath>
         </field>
     </record>

--- a/tests/data_template/module_160/views/res_partner.xml
+++ b/tests/data_template/module_160/views/res_partner.xml
@@ -10,6 +10,7 @@
                     <tree editable="bottom" delete="false">
                         <field name="id"/>
                         <field name="name"/>
+                        <field name="active" widget="toggle_button" string="Still Active"/>
                         <button name="get_formview_action" type="object" title="Open Task" icon="fa-pencil-square-o"/>
                     </tree>
                 </field>

--- a/tests/data_template/module_170/views/res_partner.xml
+++ b/tests/data_template/module_170/views/res_partner.xml
@@ -7,6 +7,7 @@
             <!-- This is a tree view for partners -->
             <tree position="inside">
                 <field name="test_field_1"/>
+                <field name="active" widget='toggle_button'/>
             </tree>
         </field>
     </record>
@@ -35,6 +36,17 @@
                 <tree>
                     <field name="name"/>
                 </tree>
+            </xpath>
+            <xpath expr="//field[@name='active']" position="attributes">
+                <attribute name="widget">toggle_button</attribute>
+            </xpath>
+            <xpath expr="//field[@name='active']" position="attributes">
+                <attribute name="widget"> toggle_button</attribute>
+            </xpath>
+            <xpath expr="//field[@name='active']" position="attributes">
+                <attribute name="widget">
+                    toggle_button
+                </attribute>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
### an example to migrating `account_invoice_select_for_payment`

```
$ python -m odoo_module_migrate -d /home/trobz/code/oca/bank-payment/16.0 -m account_invoice_select_for_payment -i 14.0 -t 18.0
Check for Odoo modules using pylint......................................Passed
11:06:37   INFO        Stage and commit changes done by pre-commit
On branch 14.0
Your branch is up to date with 'origin/14.0'.

nothing to commit, working tree clean
11:06:37   INFO        [account_invoice_select_for_payment] Running migration from 14.0 to 18.0
11:06:37   INFO        Bump version to 18.0.1.0.0
11:06:37   INFO        Replace toggle_button widget to boolean_toggle widget in file: /home/trobz/code/oca/bank-payment/16.0/account_invoice_select_for_payment/views/account_move.xml
11:06:37   INFO        Commit changes for account_invoice_select_for_payment. commit name '[MIG] account_invoice_select_for_payment: Migration to 18.0'

$ git git show --color --pretty=format:%b d95e40f9f2823d2bda83a6f208e63ad25f03e233
diff --git a/account_invoice_select_for_payment/views/account_move.xml b/account_invoice_select_for_payment/views/account_move.xml
index 7b486fb3..f3062ac9 100644
--- a/account_invoice_select_for_payment/views/account_move.xml
+++ b/account_invoice_select_for_payment/views/account_move.xml
@@ -8,7 +8,7 @@
                 <field
                     name="selected_for_payment"
                     attrs="{'invisible': [('payment_state', '!=', 'not_paid') ]}"
-                    widget="toggle_button"
+                    widget="boolean_toggle"
                 />
             </field>
         </field>
```