### PR TITLE
[IMP] tools.get_file to support single extension

### DIFF
--- a/odoo_module_migrate/tools.py
+++ b/odoo_module_migrate/tools.py
@@ -75,6 +75,9 @@ def get_files(module_path, extensions):
     if not module_dir.is_dir():
         raise Exception(f"'{module_path}' is not a valid directory.")
 
+    if isinstance(extensions, str):
+        extensions = (extensions,)
+
     for ext in extensions:
         file_paths.extend(module_dir.rglob(f"*{ext}"))
 

--- a/tests/data_result/module_170_180/security/ir.model.access.csv
+++ b/tests/data_result/module_170_180/security/ir.model.access.csv
@@ -1,0 +1,1 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink

--- a/tests/data_template/module_170/security/ir.model.access.csv
+++ b/tests/data_template/module_170/security/ir.model.access.csv
@@ -1,0 +1,1 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink


### PR DESCRIPTION
try to run tests on master branch when add `security` folder: `coverage run --source=odoo_module_migrate -m unittest discover -s tests`

- before:

```
2024-11-27 17:47:37,655,655 odoo_module_migrate.log INFO Run pre-commit
2024-11-27 17:47:38,318,318 odoo_module_migrate.log INFO [module_170] Running migration from 17.0 to 18.0
2024-11-27 17:47:38,323,323 odoo_module_migrate.log INFO Set module installable
2024-11-27 17:47:38,323,323 odoo_module_migrate.log INFO Bump version to 18.0.1.0.0
2024-11-27 17:47:38,352,352 odoo_module_migrate.log INFO Updated chatter blocks in file: /home/trobz/code/oca/odoo-module-migrator/tests/data_tmp/module_170/views/res_partner.xml
2024-11-27 17:47:38,353,353 odoo_module_migrate.log ERROR Error processing file /home/trobz/code/oca/odoo-module-migrator/tests/data_tmp/module_170/security: [Errno 21] Is a directory: '/home/trobz/code/oca/odoo-module-migrator/tests/data_tmp/module_170/security'
2024-11-27 17:47:38,355,355 odoo_module_migrate.log INFO Changing content of file: res_partner.py
```

- after:

```
2024-11-27 17:48:13,138,138 odoo_module_migrate.log INFO Run pre-commit
2024-11-27 17:48:13,816,816 odoo_module_migrate.log INFO [module_170] Running migration from 17.0 to 18.0
2024-11-27 17:48:13,821,821 odoo_module_migrate.log INFO Set module installable
2024-11-27 17:48:13,821,821 odoo_module_migrate.log INFO Bump version to 18.0.1.0.0
2024-11-27 17:48:13,849,849 odoo_module_migrate.log INFO Updated chatter blocks in file: /home/trobz/code/oca/odoo-module-migrator/tests/data_tmp/module_170/views/res_partner.xml
2024-11-27 17:48:13,851,851 odoo_module_migrate.log INFO Changing content of file: res_partner.py

```