### PR TITLE
[IMP] web.assets_common warning removed

### DIFF
--- a/odoo_module_migrate/migration_scripts/text_warnings/migrate_160_170/web_assets_common.yaml
+++ b/odoo_module_migrate/migration_scripts/text_warnings/migrate_160_170/web_assets_common.yaml
@@ -1,0 +1,2 @@
+"*":
+  web.assets_common: "[17] Reference to 'web.assets_common'. This bundle has been removed from odoo, see https://github.com/odoo/odoo/pull/132190"

--- a/tests/data_result/module_160_170/__manifest__.py
+++ b/tests/data_result/module_160_170/__manifest__.py
@@ -11,4 +11,7 @@
     'data': [
         'views/res_partner.xml',
     ],
+    "assets": {
+        "web.assets_common",
+    }
 }

--- a/tests/data_result/module_160_170/views/template.xml
+++ b/tests/data_result/module_160_170/views/template.xml
@@ -1,0 +1,5 @@
+<template id="tests_template" name="Test Template">
+    <t t-call="web.layout">
+        <t t-call-assets="web.assets_common" t-js="false"/>
+    </t>
+</template>

--- a/tests/data_template/module_160/__manifest__.py
+++ b/tests/data_template/module_160/__manifest__.py
@@ -11,4 +11,7 @@
     'data': [
         'views/res_partner.xml',
     ],
+    "assets": {
+        "web.assets_common",
+    }
 }

--- a/tests/data_template/module_160/views/template.xml
+++ b/tests/data_template/module_160/views/template.xml
@@ -1,0 +1,5 @@
+<template id="tests_template" name="Test Template">
+    <t t-call="web.layout">
+        <t t-call-assets="web.assets_common" t-js="false"/>
+    </t>
+</template>

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -143,6 +143,21 @@ class TestMigration(unittest.TestCase):
             "Differences found in the following files\n- %s"
             % ("\n- ".join(diff_files)),
         )
+        log_content = _read_content(str(self._working_path / "test_log.log"))
+        required_logs = [
+            (
+                "WARNING",
+                "[17].*'web.assets_common'.*This bundle has been removed.*",
+            ),
+        ]
+        for required_log in required_logs:
+            level, message = required_log
+            pattern = "{0}.*{1}".format(level, message)
+            self.assertNotEqual(
+                len(re.findall(pattern, log_content)),
+                0,
+                "%s not found in the log" % pattern,
+            )
 
     def test_migration_170_180(self):
         self._migrate_module("module_170", "module_170_180", "17.0", "18.0")


### PR DESCRIPTION
`web.assets_common` removed in `https://github.com/odoo/odoo/pull/132190`

run command: `python -m odoo_module_migrate -d /home/trobz/code/oca/web/17.0 -m web_assets_warmup -i 14.0 -t 17.0 -fp`

```
15:54:38   INFO        Creating new branch '17.0-mig-web_assets_warmup' ...
Switched to a new branch '17.0-mig-web_assets_warmup'
15:54:38   INFO        Getting latest changes from old branch
remote: Total 0 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
From github.com:OCA/web
 * branch                14.0       -> FETCH_HEAD
15:54:42   INFO        Run pre-commit
************* Module web_assets_warmup.__manifest__
web_assets_warmup/__manifest__.py:6: [C8106(manifest-version-format), ] Wrong Version Format "14.0.1.0.0" in manifest file. Regex to match: "(17\.0)\.\d+\.\d+\.\d+$"
15:55:07   INFO        Stage and commit changes done by pre-commit
[17.0-mig-web_assets_warmup ecb206d7b] [IMP] web_assets_warmup: pre-commit execution
 7 files changed, 49 insertions(+), 40 deletions(-)
15:55:07   INFO        [web_assets_warmup] Running migration from 14.0 to 17.0
15:55:07   INFO        Bump version to 17.0.1.0.0
15:55:07   WARNING     [17] Reference to 'web.assets_common'. This asset has been removed from the commit. More details at https://github.com/odoo/odoo/pull/132190. File /home/trobz/code/oca/web/17.0/web_assets_warmup/models/ir_actions_report.py
15:55:07   INFO        Commit changes for web_assets_warmup. commit name '[MIG] web_assets_warmup: Migration to 17.0'
```